### PR TITLE
Restrict special type to a select box

### DIFF
--- a/frontend/src/components/TypedTextField/TypedTextField.js
+++ b/frontend/src/components/TypedTextField/TypedTextField.js
@@ -4,15 +4,26 @@ import React, { forwardRef, useImperativeHandle, useState } from "react";
 const TypedTextField = forwardRef((props, ref) => {
   let [fieldType, setFieldType] = useState("integer");
   let [fieldValue, setFieldValue] = useState("");
+  let [isSpecialType, setIsSpecialType] = useState(false);
+  let [specialType, setSpecialType] = useState("get_stack");
 
   useImperativeHandle(ref, () => ({
     childFunction() {
       return {
         type: fieldType,
-        value: fieldValue,
+        value: isSpecialType ? specialType : fieldValue,
       };
     },
   }));
+
+  const onChangeFieldType = (e) => {
+    setFieldType(e.target.value);
+    if (e.target.value === "special") {
+      setIsSpecialType(true);
+    } else {
+      setIsSpecialType(false);
+    }
+  };
 
   return (
     <div>
@@ -21,22 +32,37 @@ const TypedTextField = forwardRef((props, ref) => {
         labelId="field-type-label"
         id="field-type"
         value={fieldType}
-        onChange={(e) => setFieldType(e.target.value)}
+        onChange={onChangeFieldType}
       >
         <MenuItem value="integer">Integer</MenuItem>
         <MenuItem value="object">Object</MenuItem>
         <MenuItem value="string">String</MenuItem>
         <MenuItem value="special">Special</MenuItem>
       </Select>
-      <TextField
-        label={props.fieldLabel}
-        variant="outlined"
-        sx={{
-          marginLeft: "10px",
-        }}
-        value={fieldValue}
-        onChange={(e) => setFieldValue(e.target.value)}
-      />
+      {!isSpecialType && (
+        <TextField
+          label={props.fieldLabel}
+          variant="outlined"
+          sx={{
+            marginLeft: "10px",
+          }}
+          value={fieldValue}
+          onChange={(e) => setFieldValue(e.target.value)}
+        />
+      )}
+      {isSpecialType && (
+        <>
+          <InputLabel id="special-type-label">Special Type</InputLabel>
+          <Select
+            labelId="special-type-label"
+            id="special-type"
+            value={specialType}
+            onChange={setSpecialType}
+          >
+            <MenuItem value="get_stack">Get from stack</MenuItem>
+          </Select>
+        </>
+      )}
     </div>
   );
 });


### PR DESCRIPTION
Closes #2 

**Implementation**

1. Add a new state that checks if `Special` is selected as the type in `TypedTextField`.
2. If it is not the case then render the `TextField` to let the user enter the value.
3. Otherwise render a select box with a single value 'Get from stack' as that is the only special value possible as of the current interpreter. 