### PR TITLE
Create a separate select box component

### DIFF
--- a/frontend/src/components/BinaryOperation/BinaryOperation.js
+++ b/frontend/src/components/BinaryOperation/BinaryOperation.js
@@ -1,30 +1,70 @@
-import { InputLabel, MenuItem, Select } from "@mui/material";
-import React, {
-  forwardRef,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from "react";
+import React, { forwardRef, useImperativeHandle, useRef } from "react";
 import TypedTextField from "../TypedTextField/TypedTextField";
+import SelectBox from "../SelectBox/SelectBox";
 
 const BinaryOperation = forwardRef((_props, ref) => {
-  let [operator, setOperator] = useState("+");
-
   const childRef = useRef([]);
 
   useImperativeHandle(ref, () => ({
     childFunction() {
       let data = [];
-      data.push(childRef.current[0].childFunction());
-      data.push({
-        type: "operator",
-        value: operator,
-      });
-      data.push(childRef.current[1].childFunction());
-
+      for (let i = 0; i < 3; i++) {
+        data.push(childRef.current[i].childFunction());
+      }
       return data;
     },
   }));
+
+  const menuItems = [
+    {
+      label: "+ (Addition)",
+      value: "+",
+    },
+    {
+      label: "- (Subtraction)",
+      value: "-",
+    },
+    {
+      label: "* (Multiplication)",
+      value: "*",
+    },
+    {
+      label: "/ (Division)",
+      value: "/",
+    },
+    {
+      label: "% (Modulus)",
+      value: "%",
+    },
+    {
+      label: "** (Exponentiation)",
+      value: "**",
+    },
+    {
+      label: "< (Less than)",
+      value: "<",
+    },
+    {
+      label: "<= (Less than or equal to)",
+      value: "<=",
+    },
+    {
+      label: "> (Greater than)",
+      value: ">",
+    },
+    {
+      label: ">= (Greater than or equal to)",
+      value: ">=",
+    },
+    {
+      label: "== (Equal to)",
+      value: "==",
+    },
+    {
+      label: "!= (Not equal to)",
+      value: "!=",
+    },
+  ];
 
   return (
     <div>
@@ -33,31 +73,20 @@ const BinaryOperation = forwardRef((_props, ref) => {
         ref={(el) => (childRef.current[0] = el)}
       />
       <br />
-      <InputLabel id="operator-type-label">Operator</InputLabel>
-      <Select
+      <SelectBox
+        initialValue="+"
+        onChangeHandler="set"
         labelId="operator-type-label"
         id="operator-type"
-        value={operator}
-        onChange={(e) => setOperator(e.target.value)}
-      >
-        <MenuItem value="+">+ (Addition)</MenuItem>
-        <MenuItem value="-">- (Subtraction)</MenuItem>
-        <MenuItem value="*">* (Multiplication)</MenuItem>
-        <MenuItem value="/">/ (Division)</MenuItem>
-        <MenuItem value="%">% (Modulus)</MenuItem>
-        <MenuItem value="**">** (Exponentiation)</MenuItem>
-        <MenuItem value="<">&lt; (Less than)</MenuItem>
-        <MenuItem value="<=">&lt;= (Less than or equal to)</MenuItem>
-        <MenuItem value=">">&gt; (Greater than)</MenuItem>
-        <MenuItem value=">=">&gt;= (Greater than or equal to)</MenuItem>
-        <MenuItem value="==">== (Equal to)</MenuItem>
-        <MenuItem value="!=">!= (Not equal to)</MenuItem>
-      </Select>
+        menuItems={menuItems}
+        refType="operator"
+        ref={(el) => (childRef.current[1] = el)}
+      />
       <br />
       <br />
       <TypedTextField
         fieldLabel="Right operand"
-        ref={(el) => (childRef.current[1] = el)}
+        ref={(el) => (childRef.current[2] = el)}
       />
     </div>
   );

--- a/frontend/src/components/BinaryOperation/BinaryOperation.js
+++ b/frontend/src/components/BinaryOperation/BinaryOperation.js
@@ -66,6 +66,11 @@ const BinaryOperation = forwardRef((_props, ref) => {
     },
   ];
 
+  const refDataTemplate = {
+    type: "operator",
+    value: "self",
+  };
+
   return (
     <div>
       <TypedTextField
@@ -76,10 +81,10 @@ const BinaryOperation = forwardRef((_props, ref) => {
       <SelectBox
         initialValue="+"
         onChangeHandler="set"
+        refDataTemplate={refDataTemplate}
         labelId="operator-type-label"
         id="operator-type"
         menuItems={menuItems}
-        refType="operator"
         ref={(el) => (childRef.current[1] = el)}
       />
       <br />

--- a/frontend/src/components/CodeEditor/CodeEditor.js
+++ b/frontend/src/components/CodeEditor/CodeEditor.js
@@ -37,7 +37,7 @@ const CodeEditor = () => {
       })
     );
 
-    if (response.payload.data.status == "success") {
+    if (response.payload.data.status === "success") {
       enqueueSnackbar("Code ran successfully!", { variant: "success" });
     } else {
       enqueueSnackbar("Code failed to run!", { variant: "error" });

--- a/frontend/src/components/InstructionSection/InstructionSection.js
+++ b/frontend/src/components/InstructionSection/InstructionSection.js
@@ -6,42 +6,42 @@ import React, {
 } from "react";
 
 import "./InstructionSection.css";
-import {
-  Checkbox,
-  FormControlLabel,
-  InputLabel,
-  MenuItem,
-  Select,
-} from "@mui/material";
+import { Checkbox, FormControlLabel } from "@mui/material";
 import BinaryOperation from "../BinaryOperation/BinaryOperation";
 import Input from "../Input/Input";
 import Print from "../Print/Print";
 import Var from "../Var/Var";
+import SelectBox from "../SelectBox/SelectBox";
 
 const InstructionSection = forwardRef((_props, ref) => {
-  let [instructionType, setInstructionType] = useState("binary_op");
-
-  const childRef = useRef();
+  const childRef = useRef([]);
 
   let [instructionComponent, setInstructionComponent] = useState(
-    <BinaryOperation ref={childRef} />
+    <BinaryOperation ref={(el) => (childRef.current[0] = el)} />
   );
   let [pushToStack, setPushToStack] = useState(false);
 
   const onChangeInstructionType = (e) => {
-    setInstructionType(e.target.value);
     switch (e.target.value) {
       case "binary_op":
-        setInstructionComponent(<BinaryOperation ref={childRef} />);
+        setInstructionComponent(
+          <BinaryOperation ref={(el) => (childRef.current[0] = el)} />
+        );
         break;
       case "input":
-        setInstructionComponent(<Input ref={childRef} />);
+        setInstructionComponent(
+          <Input ref={(el) => (childRef.current[0] = el)} />
+        );
         break;
       case "print":
-        setInstructionComponent(<Print ref={childRef} />);
+        setInstructionComponent(
+          <Print ref={(el) => (childRef.current[0] = el)} />
+        );
         break;
       case "var":
-        setInstructionComponent(<Var ref={childRef} />);
+        setInstructionComponent(
+          <Var ref={(el) => (childRef.current[0] = el)} />
+        );
         break;
     }
   };
@@ -49,16 +49,39 @@ const InstructionSection = forwardRef((_props, ref) => {
   useImperativeHandle(ref, () => ({
     childFunction() {
       return {
-        instruction: instructionType,
+        instruction: childRef.current[1].childFunction().instruction,
         action: pushToStack ? "store_stack" : "",
-        values: childRef.current.childFunction(),
+        values: childRef.current[0].childFunction(),
       };
     },
   }));
 
+  const menuItems = [
+    {
+      label: "Binary Operation",
+      value: "binary_op",
+    },
+    {
+      label: "Input",
+      value: "input",
+    },
+    {
+      label: "Print",
+      value: "print",
+    },
+    {
+      label: "Create variable",
+      value: "var",
+    },
+  ];
+
+  const refDataTemplate = {
+    instruction: "self",
+  };
+
   return (
     <div className="instruction-section">
-      <InputLabel id="instruction-type-label">Instruction Type</InputLabel>
+      {/* <InputLabel id="instruction-type-label">Instruction Type</InputLabel>
       <Select
         labelId="instruct-type-label"
         id="instruction-type"
@@ -69,7 +92,16 @@ const InstructionSection = forwardRef((_props, ref) => {
         <MenuItem value="input">Input</MenuItem>
         <MenuItem value="print">Print</MenuItem>
         <MenuItem value="var">Create variable</MenuItem>
-      </Select>
+      </Select> */}
+      <SelectBox
+        initialValue="binary_op"
+        onChangeHandler={onChangeInstructionType}
+        refDataTemplate={refDataTemplate}
+        labelId="instruction-type-label"
+        id="instruction-type"
+        menuItems={menuItems}
+        ref={(el) => (childRef.current[1] = el)}
+      />
 
       <br />
       <br />

--- a/frontend/src/components/InstructionSection/InstructionSection.js
+++ b/frontend/src/components/InstructionSection/InstructionSection.js
@@ -22,6 +22,7 @@ const InstructionSection = forwardRef((_props, ref) => {
   let [pushToStack, setPushToStack] = useState(false);
 
   const onChangeInstructionType = (e) => {
+    // eslint-disable-next-line
     switch (e.target.value) {
       case "binary_op":
         setInstructionComponent(

--- a/frontend/src/components/SelectBox/SelectBox.js
+++ b/frontend/src/components/SelectBox/SelectBox.js
@@ -8,16 +8,20 @@ const SelectBox = forwardRef((props, ref) => {
     if (props.onChangeHandler === "set") {
       setSelectValue(e.target.value);
     } else {
-      props.onChangeHandler(e.target.value);
+      setSelectValue(e.target.value);
+      props.onChangeHandler(e);
     }
   };
 
   useImperativeHandle(ref, () => ({
     childFunction() {
-      return {
-        type: props.refType,
-        value: selectValue,
-      };
+      let refData = {};
+      Object.keys(props.refDataTemplate).forEach((key) => {
+        const value = props.refDataTemplate[key];
+        refData[key] = value === "self" ? selectValue : value;
+      });
+
+      return refData;
     },
   }));
 

--- a/frontend/src/components/SelectBox/SelectBox.js
+++ b/frontend/src/components/SelectBox/SelectBox.js
@@ -1,0 +1,45 @@
+import { InputLabel, MenuItem, Select } from "@mui/material";
+import React, { forwardRef, useImperativeHandle, useState } from "react";
+
+const SelectBox = forwardRef((props, ref) => {
+  let [selectValue, setSelectValue] = useState(props.initialValue);
+
+  const onChangeHandler = (e) => {
+    if (props.onChangeHandler === "set") {
+      setSelectValue(e.target.value);
+    } else {
+      props.onChangeHandler(e.target.value);
+    }
+  };
+
+  useImperativeHandle(ref, () => ({
+    childFunction() {
+      return {
+        type: props.refType,
+        value: selectValue,
+      };
+    },
+  }));
+
+  return (
+    <div>
+      <InputLabel id={props.labelId}>Operator</InputLabel>
+      <Select
+        labelId={props.labelId}
+        id={props.id}
+        value={selectValue}
+        onChange={onChangeHandler}
+      >
+        {props.menuItems.map((item, idx) => {
+          return (
+            <MenuItem key={idx} value={item.value}>
+              {item.label}
+            </MenuItem>
+          );
+        })}
+      </Select>
+    </div>
+  );
+});
+
+export default SelectBox;

--- a/frontend/src/components/TypedTextField/TypedTextField.js
+++ b/frontend/src/components/TypedTextField/TypedTextField.js
@@ -1,17 +1,26 @@
 import { InputLabel, MenuItem, Select, TextField } from "@mui/material";
-import React, { forwardRef, useImperativeHandle, useState } from "react";
+import React, {
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+import SelectBox from "../SelectBox/SelectBox";
 
 const TypedTextField = forwardRef((props, ref) => {
   let [fieldType, setFieldType] = useState("integer");
   let [fieldValue, setFieldValue] = useState("");
   let [isSpecialType, setIsSpecialType] = useState(false);
-  let [specialType, setSpecialType] = useState("get_stack");
+
+  const childRef = useRef();
 
   useImperativeHandle(ref, () => ({
     childFunction() {
       return {
         type: fieldType,
-        value: isSpecialType ? specialType : fieldValue,
+        value: isSpecialType
+          ? childRef.current.childFunction().value
+          : fieldValue,
       };
     },
   }));
@@ -23,6 +32,17 @@ const TypedTextField = forwardRef((props, ref) => {
     } else {
       setIsSpecialType(false);
     }
+  };
+
+  const menuItems = [
+    {
+      label: "Get from stack",
+      value: "get_stack",
+    },
+  ];
+
+  const refDataTemplate = {
+    value: "self",
   };
 
   return (
@@ -52,15 +72,15 @@ const TypedTextField = forwardRef((props, ref) => {
       )}
       {isSpecialType && (
         <>
-          <InputLabel id="special-type-label">Special Type</InputLabel>
-          <Select
+          <SelectBox
+            initialValue="get_stack"
+            onChangeHandler="set"
+            refDataTemplate={refDataTemplate}
             labelId="special-type-label"
             id="special-type"
-            value={specialType}
-            onChange={setSpecialType}
-          >
-            <MenuItem value="get_stack">Get from stack</MenuItem>
-          </Select>
+            menuItems={menuItems}
+            ref={childRef}
+          />
         </>
       )}
     </div>


### PR DESCRIPTION
Closes #7 

**Implementation**

1. Create a new select box component, this takes in the data to be rendered, the ids for the label and the select box itself, the ref, and what should be returned by the ref child functions. 
2. Migrate all select statements to this new component, except for the one that is used to select type in `TypedTextField` because there is complex logic involved based on the value selected in the select box, and moving this to the component does not make sense, it will be clearer here. 