### PR TITLE
Create new divs to separate screen into two halves

### DIFF
--- a/frontend/src/components/CodeEditor/CodeEditor.css
+++ b/frontend/src/components/CodeEditor/CodeEditor.css
@@ -1,0 +1,27 @@
+.box {
+    margin: 10px;
+    padding: 10px;
+    border: 1px solid black;
+}
+
+.half-width {
+    width: 45%;
+}
+
+.float-left {
+    float: left;
+}
+
+.float-right {
+    float: right;
+}
+
+.code-side {
+    overflow: auto;
+    height: 90vh;
+}
+
+.output-side {
+    background-color: black;
+    color: lightgreen;
+}

--- a/frontend/src/components/CodeEditor/CodeEditor.js
+++ b/frontend/src/components/CodeEditor/CodeEditor.js
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { runCodeThunk } from "../../services/run-code-thunk";
 import InstructionSection from "../InstructionSection/InstructionSection";
 import { enqueueSnackbar } from "notistack";
+import "./CodeEditor.css";
 
 const CodeEditor = () => {
   let [instructionSections, setInstructionSections] = useState([]);
@@ -46,39 +47,52 @@ const CodeEditor = () => {
 
   return (
     <div>
-      <Button
-        variant="contained"
-        onClick={addInstructionSection}
-        sx={{
-          "margin-left": "10px",
-          "margin-right": "10px",
+      <div
+        style={{
+          float: "left",
         }}
       >
-        Add instruction
-      </Button>
-      <Button
-        variant="contained"
-        sx={{
-          "margin-left": "10px",
-          "margin-right": "10px",
-        }}
-        onClick={onRunClicked}
-      >
-        Run
-      </Button>
-
-      <div style={{ margin: "10px" }}>
-        {!runningCode && output !== "" && (
-          <>
-            <strong>Output is: </strong>
-            <pre>{output}</pre>
-          </>
-        )}
+        <Button
+          variant="contained"
+          onClick={addInstructionSection}
+          sx={{
+            "margin-left": "10px",
+            "margin-right": "10px",
+          }}
+        >
+          Add instruction
+        </Button>
+        <Button
+          variant="contained"
+          sx={{
+            "margin-left": "10px",
+            "margin-right": "10px",
+          }}
+          onClick={onRunClicked}
+        >
+          Run
+        </Button>
       </div>
 
-      {instructionSections.map((instructionSection, idx) => {
-        return <div key={idx}>{instructionSection}</div>;
-      })}
+      <br />
+      <br />
+
+      <div className="half-width float-left code-side">
+        {instructionSections.map((instructionSection, idx) => {
+          return <div key={idx}>{instructionSection}</div>;
+        })}
+      </div>
+
+      {!runningCode && output !== "" && (
+        <div className="box half-width float-right output-side">
+          <div style={{ margin: "10px" }}>
+            <>
+              <strong>Output is: </strong>
+              <pre>{output}</pre>
+            </>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/InstructionSection/InstructionSection.js
+++ b/frontend/src/components/InstructionSection/InstructionSection.js
@@ -82,18 +82,6 @@ const InstructionSection = forwardRef((_props, ref) => {
 
   return (
     <div className="instruction-section">
-      {/* <InputLabel id="instruction-type-label">Instruction Type</InputLabel>
-      <Select
-        labelId="instruct-type-label"
-        id="instruction-type"
-        value={instructionType}
-        onChange={onChangeInstructionType}
-      >
-        <MenuItem value="binary_op">Binary Operation</MenuItem>
-        <MenuItem value="input">Input</MenuItem>
-        <MenuItem value="print">Print</MenuItem>
-        <MenuItem value="var">Create variable</MenuItem>
-      </Select> */}
       <SelectBox
         initialValue="binary_op"
         onChangeHandler={onChangeInstructionType}


### PR DESCRIPTION
Closes #1 

**Implementation**

1. Split `CodeEditor` into two divs (thus two halves).
2. Fix the left side so that only that scrolls and not the entire page, this makes the 'Add Instruction' and 'Run' buttons more accessible as more instruction sections are added, it also makes the output screen more accessible. 
3. Add some nice colors to the output side (it now looks like my terminal). 